### PR TITLE
N+1になっているエンドポイントを改修

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find_by(id: params[:id])
+    @user = User.includes(:practice_records).find_by(id: params[:id])
   end
 
   def create

--- a/app/models/practice_record.rb
+++ b/app/models/practice_record.rb
@@ -8,7 +8,7 @@ class PracticeRecord < ApplicationRecord
 
   alias_attribute :details, :practice_record_details
 
-  def is_mine?(user)
+  def is_mine?(user:)
     self.user_id == user.id
   end
 end

--- a/app/views/practice_records/show.html.erb
+++ b/app/views/practice_records/show.html.erb
@@ -9,7 +9,7 @@
       <% end %>
       <p class="text-sm"><%= extract_domain_from_email(@practice_record.user.email) %></p>
     </div>
-    <% if @practice_record.is_mine?(current_user) %>
+    <% if @practice_record.is_mine?(user: current_user) %>
       <%= render 'shared/three_points_toggle' %>
     <% end %>
   </div>

--- a/app/views/shared/_mypage_practice_records_index.html.erb
+++ b/app/views/shared/_mypage_practice_records_index.html.erb
@@ -1,5 +1,5 @@
 <div class="h-0 grid gap-6 col-span-4 sm:col-span-9">
-  <% user.practice_records.each do |record| %>
+  <% @user.practice_records.each do |record| %>
     <%= link_to practice_record_path(record) do %>
       <div class="bg-white shadow rounded-lg p-6">
         <%= practiced_date_format_ja(record.practiced_date) %>


### PR DESCRIPTION
<details>

<summary>ざっくりN+1のおさらい</summary>


N+1は、親モデルと子モデル間のリレーションに関連している。

### 例

User(親)

Post(子)

Userに対して多数のPostが関連づられている場合、最初に親モデルを1回のクエリで取得し、その後に関連する子モデルのデータを個別に取得するというパターンが発生する。

```ruby
users = User.all
# select * from users

users.each do |user|
  user.post.all
end
# select * from posts where user_id = 1
# select * from posts where user_id = 2
# select * from posts where user_id = 3
# 以下userの数だけクエリが発生する
```

users = User.allとした場合、のちにusers.each { |user| user.posts }のようなアクセスをすると、User.allで1回、そしてuser.postsのアクセスでN回のクエリが発行される。

## 問題の影響

このパターンは少数のデータであれば問題になりにくいが、データ量が増えると（例えば1000人ユーザがいるとすると）クエリが1001回発行されるため、パフォーマンスに大きな影響を与える。

## 解決策の整理

1. Eager Loading(積極的読み込み)の使用

includesを使用して、リレーションされたデータを事前に取得することができる。これによりN+1クエリを1回の親モデルクエリと1回の子モデルクエリに減らすことができる。

User.includes(:posts).allのように書くと、1回のクエリでユーザを、もう1回のクエリですべての投稿をまとめて取得する。

1. joinsやpreloadとの違い
- includesは自動的にリレーションを事前取得し、N+1問題を解決するが、joinsはSQLの結合を行い、リレーションの属性を利用したクエリが可能になる。(ただし単純なクエリ取得には向いていない)
- preloadはデータベースの負荷を軽減するが、includesとは異なり追加のクエリを使用して関連モデルを取得する。
1. counter_cacheの使用

関連モデルの件数を毎回クエリで取得する場合にもN+1が発生する。counter_cacheを使用することで、件数を専用のカラムにキャッシュしておき、必要なときにこのキャッシュを参照することでクエリを減らすことができる。

1. find_eachとバッチ処理

大量のレコードを扱う場合、eachではなく、find_eachを使うことで、メモリ消費を抑えつつデータを分割して処理することができる。これはN+1とは別のパフォーマンス・チューニングのテクニックだが、全体の処理速度に大きな影響を与える場合がある。

</details>